### PR TITLE
Improve VDJ rendering

### DIFF
--- a/Source/x64/SpoutReceiver64/PixelShader.hlsl
+++ b/Source/x64/SpoutReceiver64/PixelShader.hlsl
@@ -1,0 +1,13 @@
+Texture2D texInput;
+
+SamplerState SampleType
+{
+	Filter = MIN_MAG_MIP_LINEAR;
+	AddressU = CLAMP;
+	AddressV = CLAMP;
+};
+
+float4 main(float4 position : SV_Position, float4 color : COLOR, float2 texcoord : TEXCOORD) : SV_TARGET0
+{
+	return texInput.Sample(SampleType, texcoord);
+}

--- a/Source/x64/SpoutReceiver64/VDJSpoutReceiver64.h
+++ b/Source/x64/SpoutReceiver64/VDJSpoutReceiver64.h
@@ -65,13 +65,24 @@ private:
 	unsigned int g_SenderWidth; // Width and height of the sender detected
 	unsigned int g_SenderHeight;
 
+	int oldWidth;
+	int oldHeight;
+	UINT stride;
+	UINT offset;
+
 	// DirectX
+	ID3D11Device* pDevice; // VirtualDJ D3D Device
+	ID3D11DeviceContext* pImmediateContext; // VirtualDJ D3D Device Context
+	ID3D11PixelShader* pPixelShader; // Local pixel shader
+	ID3D11Buffer* pVertexBuffer; // Texture vertex buffer
 	HANDLE g_dxShareHandle;	// Shared texture handle
 	ID3D11Texture2D* g_pSharedTexture; // Shared texture pointer
+	ID3D11Texture2D* g_pTexture; // Local texture pointer
+	ID3D11ShaderResourceView* pSRView; // Shared texture shader resource view
 	DWORD g_dwFormat; // Shared texture format
-	ID3D11Texture2D* g_pTexture; // Local texture
 	bool CreateDX11Texture(ID3D11Device* pd3dDevice, unsigned int width, unsigned int height,
 							DXGI_FORMAT format, ID3D11Texture2D** ppTexture);
+	bool UpdateVertices();
 
 	// Utility
 	SHELLEXECUTEINFOA g_ShExecInfo;


### PR DESCRIPTION
Added a local pixel shader and vertex buffer to do the rendering into VDJ.
Cached device and context instead of obtaining when used
Clear up VDJ resources when device is closed rather than plugin being closed
Create shader resource view when texture is created instead of for every frame

Feel free to take what you want from my changes. The only thing I won't push back is the project file because it had to be upgraded to work with my VS. Only project changes are:

* Removal of unused D3DX11 library as a linker dependancy
* Added PixelShader.hlsl (Pixel Shader, Model 4, Level 9_3, Header Variable Name PixelShaderCode, Header File Name PixelShader.h, Object File Name <Blank>)