### PR TITLE
Fix memory leak, Fix resize

### DIFF
--- a/Source/x64/SpoutReceiver64/VDJSpoutReceiver64.cpp
+++ b/Source/x64/SpoutReceiver64/VDJSpoutReceiver64.cpp
@@ -149,7 +149,8 @@ SpoutReceiverPlugin::SpoutReceiverPlugin()
 	bSpoutInitialized = false;
 	bSpoutPanelOpened = false;
 	bSpoutPanelActive = false;
-
+	g_ShExecInfo = { 0 };
+	
 	bSpoutOut = false; // toggle for plugin start and stop
 	bIsClosing = false; // plugin is not closing
 	SelectButton = 0;
@@ -247,6 +248,9 @@ bool SpoutReceiverPlugin::UpdateVertices()
 
 	pImmediateContext->Unmap(pVertexBuffer, NULL);
 
+	oldWidth = width;
+	oldHeight = height;
+
 	return true;
 }
 
@@ -270,9 +274,6 @@ HRESULT __stdcall  SpoutReceiverPlugin::OnDeviceInit()
 	bd.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
 	pDevice->CreateBuffer(&bd, NULL, &pVertexBuffer);
 
-	oldWidth = width;
-	oldHeight = height;
-
 	UpdateVertices();
 
 	pDevice->CreatePixelShader(PixelShaderCode, sizeof(PixelShaderCode) , nullptr, &pPixelShader);
@@ -287,6 +288,11 @@ HRESULT __stdcall SpoutReceiverPlugin::OnDeviceClose()
 
 	bIsClosing = true; // It is closing to don't do anything in draw
 
+	if (g_pSharedTexture)
+	{
+		g_pSharedTexture->Release();
+		g_pSharedTexture = nullptr;
+	}
 	if (pVertexBuffer)
 	{
 		pVertexBuffer->Release();
@@ -319,7 +325,6 @@ HRESULT __stdcall SpoutReceiverPlugin::OnDeviceClose()
 
 ULONG __stdcall SpoutReceiverPlugin::Release()
 {
-	g_pSharedTexture = nullptr;
 	g_dxShareHandle = NULL;
 	g_SenderName[0] = 0;
 	g_SenderWidth = 0;
@@ -347,11 +352,12 @@ HRESULT __stdcall SpoutReceiverPlugin::OnDraw()
 		return S_FALSE;
 
 	if (bSpoutOut) {
-
+		if (oldWidth != width || oldHeight != height) {
+			UpdateVertices();
+			OutputDebugStringA("RESIZE\n");
+		}
 		if (ReceiveSpoutTexture() && bSpoutInitialized && g_pTexture && pImmediateContext && pSRView) {
 			// A local texture, g_pTexture, has been updated
-			if (oldWidth != width || oldHeight != height)
-				UpdateVertices();
 			// Activate local shader
 			pImmediateContext->PSSetShader(pPixelShader, nullptr, 0);
 			// Bind our texture shader resource view
@@ -388,7 +394,11 @@ bool SpoutReceiverPlugin::ReceiveSpoutTexture()
 			frame.CloseAccessMutex();
 			frame.CleanupFrameCount();
 		}
-		g_pSharedTexture = nullptr; // The shared texture is different
+		if (g_pSharedTexture) // The shared texture is different
+		{
+			g_pSharedTexture->Release();
+			g_pSharedTexture = nullptr;
+		}
 		g_dxShareHandle = NULL; // And the share handle
 		// The local texture is only resized if the sender size has changed
 		bSpoutInitialized = false;
@@ -397,7 +407,6 @@ bool SpoutReceiverPlugin::ReceiveSpoutTexture()
 
 	// Find if the sender exists and return width, height, sharehandle and format.
 	if (spoutsender.FindSender(g_SenderName, senderwidth, senderheight, g_dxShareHandle, g_dwFormat)) {
-		
 		// Don't receive from VDJ itself
 		if (strcmp(g_SenderName, "VDJSpoutSender64") == 0) {
 			g_SenderName[0] = 0;
@@ -406,12 +415,10 @@ bool SpoutReceiverPlugin::ReceiveSpoutTexture()
 
 		// Check here for sender size changes to resize the local texture
 		if (g_SenderWidth != senderwidth || g_SenderHeight != senderheight) {
-
 			// Save the sender's width and height to use as necessary
 			g_SenderWidth = senderwidth;
 			g_SenderHeight = senderheight;
 			if (pDevice) {
-
 				// Existing texture must be released
 				if(g_pTexture) g_pTexture->Release();
 				g_pTexture = nullptr;
@@ -436,6 +443,12 @@ bool SpoutReceiverPlugin::ReceiveSpoutTexture()
 			bSpoutInitialized = true;
 		}
 
+		if (!g_pSharedTexture)
+		{
+			// Open the shared texture
+			spoutdx.OpenDX11shareHandle(pDevice, &g_pSharedTexture, g_dxShareHandle);
+		}
+
 		// Access the sender shared texture
 		// When it gets access and the frame is new
 		// the new shared texture pointer is retrieved.
@@ -443,18 +456,23 @@ bool SpoutReceiverPlugin::ReceiveSpoutTexture()
 		if (frame.CheckAccess()) {
 			// Check if the sender has produced a new frame
 			if (frame.GetNewFrame() && pDevice) {
-				// Get the VirtualDJ DX11 device
 				// g_dxShareHandle was retrieved from the sender
 				// The shared texture pointer can be retrieved via the sharehandle
-				if (spoutdx.OpenDX11shareHandle(pDevice, &g_pSharedTexture, g_dxShareHandle)) {
+				//if (spoutdx.OpenDX11shareHandle(pDevice, &g_pSharedTexture, g_dxShareHandle))
+				//{
 					// Now copy the shared texture to the local texture which will be the same size
 					if (g_pTexture && g_pSharedTexture && pImmediateContext) {
-							pImmediateContext->CopyResource(g_pTexture, g_pSharedTexture);
-							// The shared texture has been updated on this device
-							// so flush must be called on this device
-							pImmediateContext->Flush();
+						pImmediateContext->CopyResource(g_pTexture, g_pSharedTexture);
+						// If we are recreating the texture into g_pSharedTexture every time, then we need 
+						// to release the one we created. Can't we just keep the one texture though and
+						// recreate if needed?
+						//g_pSharedTexture->Release();
+						//g_pSharedTexture = nullptr;
+						// The shared texture has been updated on this device
+						// so flush must be called on this device
+						pImmediateContext->Flush();
 					}
-				}
+				//}
 			}
 			// Allow access to the shared texture
 			frame.AllowAccess();
@@ -469,7 +487,11 @@ bool SpoutReceiverPlugin::ReceiveSpoutTexture()
 			// Zero the name to get the active sender if it is running
 			g_SenderName[0] = 0;
 			// No need to reset the size or re-create the local texture
-			g_pSharedTexture = nullptr; // The shared texture no longer exists
+			if (g_pSharedTexture) // The shared texture no longer exists
+			{
+				g_pSharedTexture->Release();
+				g_pSharedTexture = nullptr;
+			}
 			g_dxShareHandle = NULL; // Or the share handle
 			// Close the named access mutex and frame counting
 			frame.CloseAccessMutex();


### PR DESCRIPTION
I noticed that the original code opens the shared texture on every frame, but didn't release it. I've modified the code to open it if it doesn't exist (and to release it instead of nulling it), but if for some reason that's not suitable we just need to release the shared texture on every frame.

I've also fixed a mistake in my resizing.